### PR TITLE
Rename filter from filter_html to something more specific.

### DIFF
--- a/warpwire/warpwire.module
+++ b/warpwire/warpwire.module
@@ -281,20 +281,10 @@ function warpwire_wysiwyg_plugin($editor, $version) {
  * Implementation of hook_filter_info().
  */
 function warpwire_filter_info() {
+  $filters = array();
 
-  cache_clear_all('*', 'cache_filter', TRUE);
-  cache_clear_all('*', 'cache_field', TRUE);
-
-  $filters['filter_html'] = array(
-    'title' => t('Warpwire Filter - Filtered HTML'),
-    'description' => t('Substitutes [warpwire:URL] with secure Warpwire player.'),
-    'process callback' => 'warpwire_filter',
-    'tips callback'  => 'warpwire_tips',
-    'cache' => FALSE,
-  );
-
-  $filters['full_html'] = array(
-    'title' => t('Warpwire Filter - Full HTML'),
+  $filters['warpwire'] = array(
+    'title' => t('Warpwire Filter'),
     'description' => t('Substitutes [warpwire:URL] with secure Warpwire player.'),
     'process callback' => 'warpwire_filter',
     'tips callback'  => 'warpwire_tips',


### PR DESCRIPTION
The warpwire filter is called "filter_html" which isn't very specific.

"filtered_html" is one of the stock input formats so it is also confusing at times.

This makes it more specific by changing it to "warpwire"

Note that input formats would have to be updated after this.