### PR TITLE
Use user ID for unique identifier

### DIFF
--- a/warpwire/warpwire.module
+++ b/warpwire/warpwire.module
@@ -136,7 +136,7 @@ function warpwire_external_content() {
     'lti_version' => 'LTI-1p0',
     'returnContext' => $url,
     'roles' => implode(':',$user->roles),
-    'user_id' => $user->name,
+    'user_id' => $user->uid,
     'custom_context_id' => $ww_drupal_api_unique_id,
     'custom_plugin_info' => '',
   );


### PR DESCRIPTION
The Drupal username is not persistent (users can change it in some configurations).

User ID should be used instead.